### PR TITLE
Add Amil health plan landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="pt-br">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Planos de Saúde Amil</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <h1>Planos de Saúde Amil</h1>
+      <p class="subtitle">Proteção e cuidado para você e sua empresa</p>
+      <a
+        class="cta"
+        href="https://wa.me/5511912097307"
+        target="_blank"
+        rel="noopener"
+        >Fale conosco no WhatsApp</a
+      >
+      <p class="hours">Atendimento de 2ª a 6ª feira, das 9h às 17h30</p>
+    </header>
+
+    <section class="plans">
+      <div class="plan">
+        <h2>Plano Empresarial</h2>
+        <p>
+          Ideal para empresas que buscam cuidar da saúde de seus colaboradores
+          com a qualidade Amil.
+        </p>
+        <a
+          class="cta"
+          href="https://wa.me/5511912097307?text=Quero%20saber%20sobre%20o%20Plano%20Empresarial"
+          target="_blank"
+          rel="noopener"
+          >Contratar via WhatsApp</a
+        >
+      </div>
+      <div class="plan">
+        <h2>Plano por Adesão</h2>
+        <p>
+          Plano coletivo por adesão para profissionais e suas famílias com
+          condições especiais.
+        </p>
+        <a
+          class="cta"
+          href="https://wa.me/5511912097307?text=Quero%20saber%20sobre%20o%20Plano%20por%20Ades%C3%A3o"
+          target="_blank"
+          rel="noopener"
+          >Contratar via WhatsApp</a
+        >
+      </div>
+    </section>
+
+    <footer>
+      <p>
+        WhatsApp:
+        <a href="https://wa.me/5511912097307" target="_blank" rel="noopener"
+          >+55 11 91209-7307</a
+        >
+      </p>
+      <p>Atendimento de 2ª a 6ª feira, das 9h às 17h30</p>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,64 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  color: #333;
+}
+
+.hero {
+  background: linear-gradient(135deg, #007bff, #00b4d8);
+  color: #fff;
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+.hero .cta {
+  display: inline-block;
+  margin: 1rem 0;
+  padding: 0.75rem 1.5rem;
+  background: #ffc107;
+  color: #000;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+}
+
+.plans {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 2rem 1rem;
+  gap: 2rem;
+}
+
+.plan {
+  max-width: 300px;
+  padding: 1.5rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.plan .cta {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #007bff;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+footer {
+  background: #f8f9fa;
+  text-align: center;
+  padding: 1.5rem 1rem;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  .plans {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- create landing page for Amil health plans with Empresarial and Adesão options
- add WhatsApp CTAs and service hours
- style page with gradient hero and responsive plan cards

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npx --yes prettier -c index.html styles.css`


------
https://chatgpt.com/codex/tasks/task_e_68bc40c42ff8832f94dcfe3e69b23b2a